### PR TITLE
fixed 'fm_' prefix for users table

### DIFF
--- a/system/Controller/Users/Edituser.php
+++ b/system/Controller/Users/Edituser.php
@@ -25,6 +25,9 @@ class Controller_Users_Edituser extends Controller_Users {
 				}
 
 				$err = array();
+                if ($_POST["quota_val"] != $data["quota"]) {
+                    if ($txt = $validate->quota_val($_POST["quota_val"])) { $err[] = $txt; };
+                }
 				if ($_POST["login"] != $data["login"]) {
 					if ($txt = $validate->login($_POST["login"])) { $err[] = $txt; };
 				}

--- a/system/Model/File.php
+++ b/system/Model/File.php
@@ -102,10 +102,10 @@ class Model_File extends Engine_Model {
 	
 	// FM AJAX
 	function getDirParams($did) {
-		$sql = "SELECT fd.id, fd.uid, fd.name AS `name`, fdc.right, users.login AS owner
+		$sql = "SELECT fd.id, fd.uid, fd.name AS `name`, fdc.right, fm_users.login AS owner
 		        FROM fm_dirs AS fd
 		        LEFT JOIN fm_dirs_chmod AS fdc ON (fdc.did = fd.id)
-		        LEFT JOIN users ON (users.id = fd.uid)
+		        LEFT JOIN fm_users ON (fm_users.id = fd.uid)
 		        WHERE fd.id = :did
 		        LIMIT 1";
 		
@@ -570,23 +570,23 @@ class Model_File extends Engine_Model {
 	
 	function getFileChmod() {
 		$sql = "SELECT ug.id AS pid, ug.name AS pname, usg.id AS sid, usg.name AS sname
-	        FROM users_group AS ug
-	        LEFT JOIN users_subgroup AS usg ON (usg.pid = ug.id)
+	        FROM fm_users_group AS ug
+	        LEFT JOIN fm_users_subgroup AS usg ON (usg.pid = ug.id)
 	        ORDER BY ug.id";
 	
 		$res = $this->registry['db']->prepare($sql);
 		$res->execute();
-		$this->_groups = $res->fetchAll(PDO::FETCH_ASSOC);
+		$this->fm__groups = $res->fetchAll(PDO::FETCH_ASSOC);
 	
 		$sql = "SELECT u.id, ug.id AS gid, ug.name AS gname
-	        FROM users AS u
-	        LEFT JOIN users_priv AS up ON (up.id = u.id)
-	        LEFT JOIN users_subgroup AS ug ON (ug.id = up.group)
+	        FROM fm_users AS u
+	        LEFT JOIN fm_users_priv AS up ON (up.id = u.id)
+	        LEFT JOIN fm_users_subgroup AS ug ON (ug.id = up.group)
 	        GROUP BY up.id";
 	
 		$res = $this->registry['db']->prepare($sql);
 		$res->execute();
-		$this->_users = $res->fetchAll(PDO::FETCH_ASSOC);
+		$this->fm_users = $res->fetchAll(PDO::FETCH_ASSOC);
 	}
 	
 	function getGroups() {

--- a/system/Model/File.php
+++ b/system/Model/File.php
@@ -576,7 +576,7 @@ class Model_File extends Engine_Model {
 	
 		$res = $this->registry['db']->prepare($sql);
 		$res->execute();
-		$this->fm_groups = $res->fetchAll(PDO::FETCH_ASSOC);
+		$this->_groups = $res->fetchAll(PDO::FETCH_ASSOC);
 	
 		$sql = "SELECT u.id, ug.id AS gid, ug.name AS gname
 	        FROM fm_users AS u
@@ -586,7 +586,7 @@ class Model_File extends Engine_Model {
 	
 		$res = $this->registry['db']->prepare($sql);
 		$res->execute();
-		$this->fm_users = $res->fetchAll(PDO::FETCH_ASSOC);
+		$this->_users = $res->fetchAll(PDO::FETCH_ASSOC);
 	}
 	
 	function getGroups() {

--- a/system/Model/File.php
+++ b/system/Model/File.php
@@ -576,7 +576,7 @@ class Model_File extends Engine_Model {
 	
 		$res = $this->registry['db']->prepare($sql);
 		$res->execute();
-		$this->fm__groups = $res->fetchAll(PDO::FETCH_ASSOC);
+		$this->fm_groups = $res->fetchAll(PDO::FETCH_ASSOC);
 	
 		$sql = "SELECT u.id, ug.id AS gid, ug.name AS gname
 	        FROM fm_users AS u

--- a/system/Model/Validate.php
+++ b/system/Model/Validate.php
@@ -32,5 +32,22 @@ class Model_Validate extends Engine_Model {
             return $err;
         }
     }
+
+    public function quota_val($quota_val) {
+        $err = null;
+        
+
+		if ( preg_match( '/^0$/', $quota_val ) ) {
+			$err = 'Quota value should be a positive value';
+		}
+        elseif ( !preg_match( '/^[0-9]+$/', $quota_val ) ) {
+			$err = 'Quota value should consist of numeric characters';
+		}
+        
+        if ($err != null) {
+            return $err;
+        }
+    }
+
 }    
 ?>


### PR DESCRIPTION
causing
SQLSTATE[42S02]: Base table or view not found: 1146 Table 'XXX.users' doesn't exist in ../system/Model/File.php
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'users.login' in 'field list' in ../system/Model/File.php
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'users.id' in 'on clause' in ../system/Model/File.php on line 114
